### PR TITLE
add language override to virtualsky.json

### DIFF
--- a/virtualsky.json
+++ b/virtualsky.json
@@ -13,5 +13,6 @@
 	"sky_gradient": false,
 	"gradient": false,
 	"transparent": true,
-	"objects": "M42;M45;M31;M51;M81"
+	"objects": "M42;M45;M31;M51;M81",
+	"lang": "en"
 }


### PR DESCRIPTION
this way virtualsky will always work even if it doesn't have a fitting language file for the user's browser language.