### PR TITLE
Warn no forecast

### DIFF
--- a/allsky.css
+++ b/allsky.css
@@ -175,6 +175,12 @@ img.current {
 	color: red;
 }
 
+.forecast .UNABLE_TO_GET_DATA {
+	color: red;
+	font-weight: bold;
+	font-size: 125%;
+}
+
 .forecast-map {
 	width: 75%;
 	max-width: 800px;

--- a/controller.js
+++ b/controller.js
@@ -173,7 +173,8 @@ function AppCtrl($scope, $timeout, $http, _) {
             6: "Extreme",
             7: "Extreme",
             8: "Extreme",
-            9: "Extreme"
+            9: "Extreme",
+            100: "UNABLE_TO_GET_DATA"
         };
         return scale[index];
     };
@@ -195,9 +196,13 @@ function AppCtrl($scope, $timeout, $http, _) {
         $http.get("getForecast.php")
             .then(function (response) {
                 $scope.forecast = {};
-                $scope.forecast[getDay(0)] = getSum(response.data, "day1");
-                $scope.forecast[getDay(1)] = getSum(response.data, "day2");
-                $scope.forecast[getDay(2)] = getSum(response.data, "day3");
+                if (response.data != "") {
+                    $scope.forecast[getDay(0)] = getSum(response.data, "day1");
+                    $scope.forecast[getDay(1)] = getSum(response.data, "day2");
+                    $scope.forecast[getDay(2)] = getSum(response.data, "day3");
+                } else {
+                    $scope.forecast[getDay(0)] = 100;
+                }
             });
     };
 

--- a/getForecast.php
+++ b/getForecast.php
@@ -1,25 +1,28 @@
 <?php
-$forecast   = file_get_contents('http://services.swpc.noaa.gov/text/3-day-forecast.txt');
-//echo $homepage;
-$stripStart = substr($forecast, strpos($forecast, "00-03UT"));
-$kpTable    = substr($stripStart, 0, strpos($stripStart, "Rationale") -2 );
-//echo $kpTable;
+$url = "http://services.swpc.noaa.gov/text/3-day-forecast.txt";
+$forecast   = file_get_contents($url);
+if ($forecast != "") {
+    $stripStart = substr($forecast, strpos($forecast, "00-03UT"));
+    $kpTable    = substr($stripStart, 0, strpos($stripStart, "Rationale") -2 );
+    //echo $kpTable;
 
-$rows       = explode("\n", $kpTable);
+    $rows       = explode("\n", $kpTable);
 
-foreach($rows as $row => $data)
-{
-    //get row data
-    $noBrackets = preg_replace("/\([^)]+\)/","", $data);
-    $dataFormatted = preg_replace('!\s+!', ' ', $noBrackets);
-    $row_data = explode(' ', $dataFormatted);
+    foreach($rows as $row => $data)
+    {
+        //get row data
+        $noBrackets = preg_replace("/\([^)]+\)/","", $data);
+        $dataFormatted = preg_replace('!\s+!', ' ', $noBrackets);
+        $row_data = explode(' ', $dataFormatted);
 
-    $info[$row]['time']  = $row_data[0];
-    $info[$row]['day1']  = $row_data[1];
-    $info[$row]['day2']  = $row_data[2];
-    $info[$row]['day3']  = $row_data[3];
+        $info[$row]['time']  = $row_data[0];
+        $info[$row]['day1']  = $row_data[1];
+        $info[$row]['day2']  = $row_data[2];
+        $info[$row]['day3']  = $row_data[3];
+    }
+
+    echo json_encode($info);
+} else {
+    echo "ERROR: Unable to get data from '$url'";
 }
-
-echo json_encode($info);
-
 ?>


### PR DESCRIPTION
Warn the user if we're unable to get the Aurora forecast from the website.
While testing, the site was down but there was no notification on the web page.
These changes fix that.