### PR TITLE
getForecast.php: ignore warning messages

### DIFF
--- a/getForecast.php
+++ b/getForecast.php
@@ -1,11 +1,12 @@
 <?php
 $url = "http://services.swpc.noaa.gov/text/3-day-forecast.txt";
+// Don't want warning messages to go into the web log for things like the server is down.
+// We display a message to the user which is sufficient.
+error_reporting(E_ALL ^ E_WARNING);
 $forecast   = file_get_contents($url);
 if ($forecast != "") {
     $stripStart = substr($forecast, strpos($forecast, "00-03UT"));
     $kpTable    = substr($stripStart, 0, strpos($stripStart, "Rationale") -2 );
-    //echo $kpTable;
-
     $rows       = explode("\n", $kpTable);
 
     foreach($rows as $row => $data)


### PR DESCRIPTION
Don't have the web server log an error if we can't get to the URL since we're already notifying the user.
Putting a message in the web log file just clutters it up.