### PR TITLE
functions.php: fix placeholder

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,8 @@ define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
 
 // If on a Pi, check that the placholder was replaced.
 exec("grep 'Model.*: Raspberry' /proc/cpuinfo", $on_Pi);
-if ($on_Pi[0] != "" && ALLSKY_CONFIG == "XX_ALLSKY_CONFIG_XX") {
+// Split the placeholder so it doesn't get replaced if the update script is run multiple times.
+if ($on_Pi[0] != "" && ALLSKY_CONFIG == "XX_ALLSKY_CONFIG" . "_XX") {
 	// This file hasn't been updated yet after installation.
 	echo "<div style='font-size: 200%;'>";
 	echo "<span style='color: red'>";


### PR DESCRIPTION
If the placeholder "XX_ALLSKY_CONFIG_XX" is replaced more than once, the "if" statement on line 10 breaks, so split the placeholder so a "grep" of it doesn't find it.