### PR TITLE
allsky.cs: don't stretch thumbnails

### DIFF
--- a/allsky.css
+++ b/allsky.css
@@ -147,7 +147,7 @@ img.current {
 }
 
 .archived-videos .day-container .image-container img{
-	width: 100%;
+	max-width: 100%;
 	max-height: 100%;
 }
 


### PR DESCRIPTION
With "width: 100%" the thumbnails (which are usually only 100px wide) were stretched to the container which is 160 px wide.  It made them look wierd.