### PR TITLE
Add support for jpeg|png for images and webm for video

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,9 +5,10 @@
 define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
 
 // If on a Pi, check that the placholder was replaced.
-exec("grep 'Model.*: Raspberry' /proc/cpuinfo", $on_Pi);
+exec("grep -q 'Model.*: Raspberry' /proc/cpuinfo", $none, $return);
 // Split the placeholder so it doesn't get replaced if the update script is run multiple times.
-if ($on_Pi[0] != "" && ALLSKY_CONFIG == "XX_ALLSKY_CONFIG" . "_XX") {
+// Note: return code 0 == a match, return code 1 == no match
+if ($return==0 && ALLSKY_CONFIG == "XX_ALLSKY_CONFIG" . "_XX") {
 	// This file hasn't been updated yet after installation.
 	echo "<div style='font-size: 200%;'>";
 	echo "<span style='color: red'>";

--- a/functions.php
+++ b/functions.php
@@ -59,9 +59,9 @@ function make_thumb($src, $dest, $desired_width)
 {
  	/* Make sure the imagecreatefromjpeg() function is in PHP. */
 	global $displayed_thumbnail_error_message;
-	if ( preg_match("/^.*\.(jpg|jpeg)$/", $src ) ) {
+	if ( preg_match("/\.(jpg|jpeg)$/", $src ) ) {
 		$funcext='jpeg';
-	} elseif ( preg_match("/^.*\.png$/", $src ) ) {
+	} elseif ( preg_match("/\.png$/", $src ) ) {
 		$funcext='png';
 	}
 	if (function_exists("imagecreatefrom${funcext}") == false)
@@ -120,9 +120,9 @@ function display_thumbnails($image_type)
 	global $back_button;
 	$image_type_len = strlen($image_type);
 	if ($image_type == "Timelapse") {
-		$ext = "/^.*\.(mp4|webm)$/";
+		$ext = "/\.(mp4|webm)$/";
 	} else {
-		$ext = "/^.*\.(jpg|jpeg|png)$/";
+		$ext = "/\.(jpg|jpeg|png)$/";
 	}
 
 	$num_files = 0;

--- a/functions.php
+++ b/functions.php
@@ -58,18 +58,24 @@ function make_thumb($src, $dest, $desired_width)
 {
  	/* Make sure the imagecreatefromjpeg() function is in PHP. */
 	global $displayed_thumbnail_error_message;
-	if (function_exists('imagecreatefromjpeg') == false)
+	if ( preg_match("/^.*\.(jpg|jpeg)$/", $src ) ) {
+		$funcext='jpeg';
+	} elseif ( preg_match("/^.*\.png$/", $src ) ) {
+		$funcext='png';
+	}
+	if (function_exists("imagecreatefrom${funcext}") == false)
 	{
 		if ($displayed_thumbnail_error_message == false)
 		{
-			echo "<br><p style='color: red'>Unable to make thumbnail(s); imagecreatefromjpeg() does not exist.<br>If you do NOT have the file '/etc/php/7.3/mods-available/gd.ini' you need to download the latest PHP.</p>";
+			echo "<br><p style='color: red'>Unable to make thumbnail(s); imagecreatefrom{$funcext}() does not exist.<br>If you do NOT have the file '/etc/php/7.3/mods-available/gd.ini' you need to download the latest PHP.</p>";
 			$displayed_thumbnail_error_message = true;
 		}
 		return(false);
 	}
 
 	/* read the source image */
-	$source_image = imagecreatefromjpeg($src);
+	$funcname="imagecreatefrom{$funcext}";
+	$source_image = $funcname($src);
 	$width = imagesx($source_image);
 	$height = imagesy($source_image);
 
@@ -83,7 +89,8 @@ function make_thumb($src, $dest, $desired_width)
 	imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height);
 
 	/* create the physical thumbnail image to its destination */
- 	imagejpeg($virtual_image, $dest);
+	$funcname="image{$funcext}";
+ 	$funcname($virtual_image, $dest);
 
 	if (file_exists($dest)) {
 		return(true);
@@ -113,16 +120,16 @@ function display_thumbnails($image_type)
 	global $back_button;
 	$image_type_len = strlen($image_type);
 	if ($image_type == "Timelapse") {
-		$ext = "mp4";
+		$ext = "/^.*\.(mp4|webm)$/";
 	} else {
-		$ext = "jpg";
+		$ext = "/^.*\.(jpg|jpeg|png)$/";
 	}
 
 	$num_files = 0;
 	$files = array();
 	if ($handle = opendir('.')) {
 		while (false !== ($entry = readdir($handle))) {
-			if (strpos($entry, $ext) !== false) {
+			if ( preg_match( $ext, $entry ) ) {
 				$files[] = $entry;;
 				$num_files++;
 			}

--- a/functions.php
+++ b/functions.php
@@ -90,8 +90,7 @@ function make_thumb($src, $dest, $desired_width)
 	imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height);
 
 	/* create the physical thumbnail image to its destination */
-	$funcname="image{$funcext}";
- 	$funcname($virtual_image, $dest);
+ 	imagejpeg($virtual_image, $dest);
 
 	if (file_exists($dest)) {
 		return(true);

--- a/functions.php
+++ b/functions.php
@@ -156,7 +156,7 @@ function display_thumbnails($image_type)
 	$thumbnailSizeX = get_variable(ALLSKY_CONFIG .'/config.sh', 'THUMBNAILSIZE_X=', '100');
 	foreach ($files as $file) {
 		// The thumbnail should be a .jpg.
-		$thumbnail = str_replace(".mp4", ".jpg", "thumbnails/$file");
+		$thumbnail = preg_replace($ext, ".jpg", "thumbnails/$file");
 		if (! file_exists($thumbnail)) {
 			if ($image_type == "Timelapse") {
 				if (! make_thumb_from_video($file, $thumbnail, $thumbnailSizeX)) {


### PR DESCRIPTION
Creates support for additional extensions which may be used:
- For Image thumbnails, adds support for `jpeg` and `png`, in addition to the original `jpg`
- For Video thumbnails, adds support for `webm`, in addition to the original `mp4`.

Also cleans up the Raspberry Pi detection to remove logged errors on non-Pi platforms:
```
PHP message: PHP Notice:  Undefined offset: 0 in functions.php on line 9
```

Fixes [allsky#989](https://github.com/thomasjacquin/allsky/issues/989)
