### PR TITLE
Thumbnail checks and fixes

### DIFF
--- a/allsky.css
+++ b/allsky.css
@@ -226,3 +226,7 @@ img.current {
 	max-width: 800px;
 	margin-top: 30px;
 }
+
+.thumbnailError {
+	color: red;
+}

--- a/functions.php
+++ b/functions.php
@@ -128,6 +128,11 @@ function make_thumb($src, $dest, $desired_width)
 	// echo "<br>flushing after $dest:";
 	flush();	// flush even if we couldn't make the thumbnail so the user sees this file immediately.
 	if (file_exists($dest)) {
+		if (filesize($dest) === 0) {
+			echo "<br><p style='color: red'>Unable to make thumbnail for '$dest': thumbnail was empty!</p>";
+			unlink($dest);
+			return(false);
+		}
 		return(true);
 	} else {
 		echo "<p>Unable to create thumbnail for '$src': <b>" . error_get_last()['message'] . "</b></p>";
@@ -164,6 +169,11 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 	$command = "ffmpeg -loglevel warning -ss 00:00:$sec -i '$src' -filter:v scale='$desired_width:-1' -frames:v 1 '$dest' 2>&1";
 	exec($command, $output);
 	if (file_exists($dest)) {
+		if (filesize($dest) === 0) {
+			echo "<br><p style='color: red'>Unable to make thumbnail for '$dest': thumbnail was empty!</p>";
+			unlink($dest);
+			return(false);
+		}
 		return(true);
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -94,11 +94,11 @@ $displayed_thumbnail_error_message = false;
 function make_thumb($src, $dest, $desired_width)
 {
 	if (! file_exists($src)) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' does not exist!</p>";
+		echo "<br><p class='thumbnailError'>Unable to make thumbnail: '$src' does not exist!</p>";
 		return(false);
 	}
 	if (filesize($src) === 0) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
+		echo "<br><p class='thumbnailError'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
 		unlink($src);
 		return(false);
 	}
@@ -114,7 +114,7 @@ function make_thumb($src, $dest, $desired_width)
 	{
 		if ($displayed_thumbnail_error_message == false)
 		{
-			echo "<br><p style='color: red'>Unable to make thumbnail(s); imagecreatefrom{$funcext}() does not exist.<br>If you do NOT have the file '/etc/php/7.3/mods-available/gd.ini' you need to download the latest PHP.</p>";
+			echo "<br><p class='thumbnailError'>Unable to make thumbnail(s); imagecreatefrom{$funcext}() does not exist.<br>If you do NOT have the file '/etc/php/7.3/mods-available/gd.ini' you need to download the latest PHP.</p>";
 			$displayed_thumbnail_error_message = true;
 		}
 		return(false);
@@ -144,13 +144,13 @@ function make_thumb($src, $dest, $desired_width)
 	flush();	// flush even if we couldn't make the thumbnail so the user sees this file immediately.
 	if (file_exists($dest)) {
 		if (filesize($dest) === 0) {
-			echo "<br><p style='color: red'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
+			echo "<br><p class='thumbnailError'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
 			unlink($dest);
 			return(false);
 		}
 		return(true);
 	} else {
-		echo "<p style='color: red'>Unable to create thumbnail for '$src': <b>" . error_get_last()['message'] . "</b></p>";
+		echo "<p class='thumbnailError'>Unable to create thumbnail for '$src': <b>" . error_get_last()['message'] . "</b></p>";
 		return(false);
 	}
 }
@@ -172,11 +172,11 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 	}
 
 	if (! file_exists($src)) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' does not exist!</p>";
+		echo "<br><p class='thumbnailError'>Unable to make thumbnail: '$src' does not exist!</p>";
 		return(false);
 	}
 	if (filesize($src) === 0) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
+		echo "<br><p class='thumbnailError'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
 		unlink($src);
 		return(false);
 	}
@@ -194,7 +194,7 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 	exec($command, $output);
 	if (file_exists($dest)) {
 		if (filesize($dest) === 0) {
-			echo "<br><p style='color: red'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
+			echo "<br><p class='thumbnailError'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
 			unlink($dest);
 			return(false);
 		}

--- a/functions.php
+++ b/functions.php
@@ -127,6 +127,8 @@ function make_thumb($src, $dest, $desired_width)
 	$height = imagesy($source_image);
 
 	/* find the "desired height" of this thumbnail, relative to the desired width  */
+	if ($desired_width > $width)
+		$desired_width = $width;	// This might create a very tall thumbnail...
 	$desired_height = floor($height * ($desired_width / $width));
 
 	/* create a new, "virtual" image */
@@ -142,13 +144,13 @@ function make_thumb($src, $dest, $desired_width)
 	flush();	// flush even if we couldn't make the thumbnail so the user sees this file immediately.
 	if (file_exists($dest)) {
 		if (filesize($dest) === 0) {
-			echo "<br><p style='color: red'>Unable to make thumbnail for '$dest': thumbnail was empty!</p>";
+			echo "<br><p style='color: red'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
 			unlink($dest);
 			return(false);
 		}
 		return(true);
 	} else {
-		echo "<p>Unable to create thumbnail for '$src': <b>" . error_get_last()['message'] . "</b></p>";
+		echo "<p style='color: red'>Unable to create thumbnail for '$src': <b>" . error_get_last()['message'] . "</b></p>";
 		return(false);
 	}
 }
@@ -192,7 +194,7 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 	exec($command, $output);
 	if (file_exists($dest)) {
 		if (filesize($dest) === 0) {
-			echo "<br><p style='color: red'>Unable to make thumbnail for '$dest': thumbnail was empty!</p>";
+			echo "<br><p style='color: red'>Unable to make thumbnail for '$src': thumbnail was empty!  Using full-size image for thumbnail.</p>";
 			unlink($dest);
 			return(false);
 		}

--- a/functions.php
+++ b/functions.php
@@ -98,7 +98,8 @@ function make_thumb($src, $dest, $desired_width)
 		return(false);
 	}
 	if (filesize($src) === 0) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!</p>";
+		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
+		unlink($src);
 		return(false);
 	}
 
@@ -166,7 +167,6 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 	}
 
 	if (! can_make_video_thumbnails()) {
-// echo "Can't make video thumbnail - can_make_video_thumbnails=false";
 		return(false);
 	}
 
@@ -175,7 +175,8 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 		return(false);
 	}
 	if (filesize($src) === 0) {
-		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!</p>";
+		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!  Removed it.</p>";
+		unlink($src);
 		return(false);
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -84,6 +84,10 @@ function make_thumb($src, $dest, $desired_width)
 		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' does not exist!</p>";
 		return(false);
 	}
+	if (filesize($src) === 0) {
+		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!</p>";
+		return(false);
+	}
 
  	/* Make sure the imagecreatefromjpeg() function is in PHP. */
 	global $displayed_thumbnail_error_message;
@@ -141,6 +145,10 @@ function make_thumb_from_video($src, $dest, $desired_width, $attempts)
 
 	if (! file_exists($src)) {
 		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' does not exist!</p>";
+		return(false);
+	}
+	if (filesize($src) === 0) {
+		echo "<br><p style='color: red'>Unable to make thumbnail: '$src' is empty!</p>";
 		return(false);
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -122,7 +122,7 @@ function make_thumb($src, $dest, $desired_width)
 
 	/* read the source image */
 	$funcname="imagecreatefrom{$funcext}";
-	$source_image = @$funcname($src);
+	$source_image = $funcname($src);
 	$width = imagesx($source_image);
 	$height = imagesy($source_image);
 
@@ -136,10 +136,9 @@ function make_thumb($src, $dest, $desired_width)
 	imagecopyresampled($virtual_image, $source_image, 0, 0, 0, 0, $desired_width, $desired_height, $width, $height);
 
 	/* create the physical thumbnail image to its destination */
- 	imagejpeg($virtual_image, $dest);
+ 	@imagejpeg($virtual_image, $dest);
 
 	// flush so user sees thumbnails as they are created, instead of waiting for them all.
-	// echo "<br>flushing after $dest:";
 	flush();	// flush even if we couldn't make the thumbnail so the user sees this file immediately.
 	if (file_exists($dest)) {
 		if (filesize($dest) === 0) {


### PR DESCRIPTION
* Check for 0-length input images and thumbnails and display appropriate message.
* Handle very narrow input images, for example, 1-pixel wide.