### PR TITLE
controller.js: use correct number for average

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -502,7 +502,7 @@ function AppCtrl($scope, $timeout, $http, _) {
 				var total = _.sumBy(data, function (row) {
 					return parseInt(row[field]);
 				});
-				return Math.round(total / 7);
+				return Math.round(total / data.length);	// return the average
 			}
 
 			function getDay(number) {


### PR DESCRIPTION
There are 8 aurora lines, not 7, but use the length of the array instead of hard-coding 8.